### PR TITLE
Update dependabot schedules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,18 @@ updates:
         - saturday
         - sunday
     open-pull-requests-limit: 10
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      time: "09:00"
+      timezone: Asia/Tokyo
+      day:
+        - monday
+        - tuesday
+        - wednesday
+        - thursday
+        - friday
+        - saturday
+        - sunday
+    open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,17 @@
 version: 2
 updates:
-- package-ecosystem: cargo
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "09:00"
-    timezone: Asia/Tokyo
-  open-pull-requests-limit: 10
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+      time: "09:00"
+      timezone: Asia/Tokyo
+      day:
+        - monday
+        - tuesday
+        - wednesday
+        - thursday
+        - friday
+        - saturday
+        - sunday
+    open-pull-requests-limit: 10


### PR DESCRIPTION
This pull request updates the dependabot schedule for cargo packages to run weekly at 09:00 in the Asia/Tokyo timezone, every day of the week. Additionally, it adds a new dependabot schedule for GitHub Actions with the same configuration. This change ensures that dependabot will regularly check for updates and create pull requests for both cargo packages and GitHub Actions.