### PR TITLE
Change schedule from weekly to daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,14 +6,6 @@ updates:
       interval: weekly
       time: "09:00"
       timezone: Asia/Tokyo
-      day:
-        - monday
-        - tuesday
-        - wednesday
-        - thursday
-        - friday
-        - saturday
-        - sunday
     open-pull-requests-limit: 10
   - package-ecosystem: github-actions
     directory: "/"
@@ -21,12 +13,4 @@ updates:
       interval: weekly
       time: "09:00"
       timezone: Asia/Tokyo
-      day:
-        - monday
-        - tuesday
-        - wednesday
-        - thursday
-        - friday
-        - saturday
-        - sunday
     open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,14 +3,14 @@ updates:
   - package-ecosystem: cargo
     directory: "/"
     schedule:
-      interval: weekly
+      interval: daily
       time: "09:00"
       timezone: Asia/Tokyo
     open-pull-requests-limit: 10
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: weekly
+      interval: daily
       time: "09:00"
       timezone: Asia/Tokyo
     open-pull-requests-limit: 10


### PR DESCRIPTION
Update the schedule for package ecosystems to run daily instead of weekly, removing the day of the week specification.